### PR TITLE
Removed event type specificity in measurements interface, both during modeling and generation.

### DIFF
--- a/EventStream/data/config.py
+++ b/EventStream/data/config.py
@@ -641,6 +641,12 @@ class MeasurementConfig(JSONableMixin):
                     raise ValueError(
                         f"functor should be None for {self.temporality} measurements! Got {self.functor}"
                     )
+                if self.modality == DataModality.SINGLE_LABEL_CLASSIFICATION:
+                    raise ValueError(
+                        f"{self.modality} on {self.temporality} measurements is not currently supported, as "
+                        "event aggregation can turn single-label tasks into multi-label tasks in a manner "
+                        "that is not currently automatically detected or compensated for."
+                    )
 
             case TemporalityType.FUNCTIONAL_TIME_DEPENDENT:
                 if self.functor is None:

--- a/EventStream/data/config.py
+++ b/EventStream/data/config.py
@@ -409,7 +409,6 @@ class VocabularyConfig(JSONableMixin):
     vocab_offsets_by_measurement: dict[str, int] | None = None
     measurements_idxmap: dict[str, dict[Hashable, int]] | None = None
     measurements_per_generative_mode: dict[DataModality, list[str]] | None = None
-    event_types_per_measurement: dict[str, list[str]] | None = None
     event_types_idxmap: dict[str, int] | None = None
 
     @property
@@ -563,11 +562,6 @@ class MeasurementConfig(JSONableMixin):
             The fraction of valid instances in which this measure is observed. Is set dynamically during
             pre-procesisng, and not specified at construction.
 
-        # Specific to dynamic measures
-        `present_in_event_types` (`Optional[List[str]]`, defaults to `None`):
-            Within which event types this column can be present.
-            If `None`, this column can be present in *all* event types.
-
         # Specific to time-dependent measures
         `functor` (`Optional[TimeDependentFunctor]`, defaults to `None`):
             The functor used to compute the value of a known-time-depedency measure (e.g., Age). Must be None
@@ -616,9 +610,6 @@ class MeasurementConfig(JSONableMixin):
     modality: DataModality | None = None
     observation_frequency: float | None = None
 
-    # Specific to dynamic measures
-    present_in_event_types: list[str] | None = None
-
     # Specific to time-dependent measures
     functor: TimeDependentFunctor | None = None
 
@@ -636,11 +627,6 @@ class MeasurementConfig(JSONableMixin):
         """Checks the internal state of `self` and ensures internal consistency and validity."""
         match self.temporality:
             case TemporalityType.STATIC:
-                if self.present_in_event_types is not None:
-                    raise ValueError(
-                        f"present_in_event_types should be None for {self.temporality} measurements! Got "
-                        f"{self.present_in_event_types}"
-                    )
                 if self.functor is not None:
                     raise ValueError(
                         f"functor should be None for {self.temporality} measurements! Got {self.functor}"
@@ -659,11 +645,6 @@ class MeasurementConfig(JSONableMixin):
             case TemporalityType.FUNCTIONAL_TIME_DEPENDENT:
                 if self.functor is None:
                     raise ValueError(f"functor must be set for {self.temporality} measurements!")
-                if self.present_in_event_types is not None:
-                    raise ValueError(
-                        f"present_in_event_types should be None for {self.temporality} measurements! Got "
-                        f"{self.present_in_event_types}"
-                    )
 
                 if self.modality is None:
                     self.modality = self.functor.OUTPUT_MODALITY

--- a/EventStream/transformer/conditionally_independent_model.py
+++ b/EventStream/transformer/conditionally_independent_model.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any
 
 import torch
@@ -56,10 +55,6 @@ class ConditionallyIndependentGenerativeOutputLayer(GenerativeOutputLayerBase):
             + self.config.measurements_for(DataModality.UNIVARIATE_REGRESSION)
         )
 
-        if is_generation:
-            warnings.warn("Event type mask per measurement is likely WRONG in generative case!")
-        event_type_mask_per_measurement = self.get_event_type_mask_per_measurement(batch)
-
         # encoded is of shape: (batch size, sequence length, config.hidden_size)
         bsz, seq_len, _ = encoded.shape
         whole_event_encoded = encoded
@@ -86,7 +81,6 @@ class ConditionallyIndependentGenerativeOutputLayer(GenerativeOutputLayerBase):
             batch,
             for_event_contents_prediction,
             classification_measurements,
-            event_type_mask_per_measurement=event_type_mask_per_measurement,
         )
         classification_dists_by_measurement.update(classification_out[1])
         if not is_generation:
@@ -98,7 +92,6 @@ class ConditionallyIndependentGenerativeOutputLayer(GenerativeOutputLayerBase):
             for_event_contents_prediction,
             regression_measurements,
             is_generation=is_generation,
-            event_type_mask_per_measurement=event_type_mask_per_measurement,
         )
         regression_dists.update(regression_out[1])
         if not is_generation:
@@ -140,7 +133,6 @@ class ConditionallyIndependentGenerativeOutputLayer(GenerativeOutputLayerBase):
                     regression_indices=regression_indices,
                     time_to_event=None if is_generation else TTE_true,
                 ),
-                "event_type_mask_per_measurement": event_type_mask_per_measurement,
                 "event_mask": batch["event_mask"],
                 "dynamic_values_mask": batch["dynamic_values_mask"],
             }

--- a/EventStream/transformer/config.py
+++ b/EventStream/transformer/config.py
@@ -332,8 +332,6 @@ class StructuredTransformerConfig(PretrainedConfig):
             A map per data type of the integer index corresponding to each vocabulary element.
         measurements_per_generative_mode (`Dict[DataModality, List[str]]`):
             Which measurements (by str name) are generated in which mode.
-        event_types_per_measurement (`Dict[str, List[str]]`, *optional*, defaults to None):
-            Which measurements (by str name) are associated with each event type (by str name).
         event_types_idxmap (`Dict[str, int]`, *optional*, defaults to None):
             A map of the integer index corresponding to each event type.
         measurements_per_dep_graph_level (`List[List[MEAS_INDEX_GROUP_T]]`, *optional*, defaults to None):
@@ -462,7 +460,6 @@ class StructuredTransformerConfig(PretrainedConfig):
         measurement_configs: dict[str, MeasurementConfig] | None = None,
         measurements_idxmap: dict[str, dict[Hashable, int]] | None = None,
         measurements_per_generative_mode: dict[DataModality, list[str]] | None = None,
-        event_types_per_measurement: dict[str, list[str]] | None = None,
         event_types_idxmap: dict[str, int] | None = None,
         measurements_per_dep_graph_level: list[list[MEAS_INDEX_GROUP_T]] | None = None,
         max_seq_len: int = 256,
@@ -514,14 +511,11 @@ class StructuredTransformerConfig(PretrainedConfig):
             measurements_idxmap = {}
         if measurements_per_generative_mode is None:
             measurements_per_generative_mode = {}
-        if event_types_per_measurement is None:
-            event_types_per_measurement = {}
         if event_types_idxmap is None:
             event_types_idxmap = {}
         if measurement_configs is None:
             measurement_configs = {}
 
-        self.event_types_per_measurement = event_types_per_measurement
         self.event_types_idxmap = event_types_idxmap
 
         if measurement_configs:
@@ -868,7 +862,6 @@ class StructuredTransformerConfig(PretrainedConfig):
                     f"{in_generative_mode - in_dep}"
                 )
 
-        self.event_types_per_measurement = dataset.vocabulary_config.event_types_per_measurement
         self.event_types_idxmap = dataset.vocabulary_config.event_types_idxmap
 
         self.vocab_offsets_by_measurement = dataset.vocabulary_config.vocab_offsets_by_measurement

--- a/EventStream/transformer/lightning_modules/generative_modeling.py
+++ b/EventStream/transformer/lightning_modules/generative_modeling.py
@@ -344,14 +344,7 @@ class ESTForGenerativeSequenceModelingLM(L.LightningModule):
 
         # Per data type
         for measurement, metrics_dict in self.metrics.items():
-            if (results["event_type_mask_per_measurement"] is None) or (
-                measurement not in results["event_type_mask_per_measurement"]
-            ):
-                mask = results["event_mask"]
-            else:
-                mask = (
-                    results["event_mask"] & results["event_type_mask_per_measurement"][measurement]
-                )
+            mask = results["event_mask"]
 
             if not mask.any():
                 continue

--- a/EventStream/transformer/nested_attention_model.py
+++ b/EventStream/transformer/nested_attention_model.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any
 
 import torch
@@ -70,17 +69,6 @@ class NestedAttentionGenerativeOutputLayer(GenerativeOutputLayerBase):
             + self.config.measurements_for(DataModality.UNIVARIATE_REGRESSION)
         )
 
-        if is_generation:
-            if self.config.measurements_per_dep_graph_level[1] != ["event_type"]:
-                event_type_mask_per_measurement = self.get_event_type_mask_per_measurement(batch)
-            else:
-                warnings.warn(
-                    "Event type mask per measurement is likely WRONG in generative case!"
-                )
-                event_type_mask_per_measurement = None
-        else:
-            event_type_mask_per_measurement = self.get_event_type_mask_per_measurement(batch)
-
         bsz, seq_len, dep_graph_len, _ = encoded.shape
 
         if dep_graph_el_generation_target is not None:
@@ -143,7 +131,6 @@ class NestedAttentionGenerativeOutputLayer(GenerativeOutputLayerBase):
                     batch,
                     dep_graph_level_encoded,
                     classification_measurements_in_level,
-                    event_type_mask_per_measurement=event_type_mask_per_measurement,
                 )
                 classification_dists_by_measurement.update(classification_out[1])
                 if not is_generation:
@@ -155,7 +142,6 @@ class NestedAttentionGenerativeOutputLayer(GenerativeOutputLayerBase):
                     dep_graph_level_encoded,
                     regression_measurements_in_level,
                     is_generation=is_generation,
-                    event_type_mask_per_measurement=event_type_mask_per_measurement,
                 )
                 regression_dists.update(regression_out[1])
                 if not is_generation:
@@ -201,7 +187,6 @@ class NestedAttentionGenerativeOutputLayer(GenerativeOutputLayerBase):
                     regression_indices=regression_indices,
                     time_to_event=None if is_generation else TTE_true,
                 ),
-                "event_type_mask_per_measurement": event_type_mask_per_measurement,
                 "event_mask": batch["event_mask"],
                 "dynamic_values_mask": batch["dynamic_values_mask"],
             }

--- a/tests/data/test_config.py
+++ b/tests/data/test_config.py
@@ -76,7 +76,7 @@ class TestMeasurementConfig(ConfigComparisonsMixin, unittest.TestCase):
         valid_kwargs = [
             dict(
                 temporality=TemporalityType.DYNAMIC,
-                modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
+                modality=DataModality.MULTI_LABEL_CLASSIFICATION,
             ),
             dict(
                 temporality=TemporalityType.STATIC,
@@ -103,6 +103,10 @@ class TestMeasurementConfig(ConfigComparisonsMixin, unittest.TestCase):
             MeasurementConfig(**kwargs)
 
         invalid_kwargs = [
+            dict(
+                temporality=TemporalityType.DYNAMIC,
+                modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
+            ),
             dict(
                 temporality=TemporalityType.STATIC,
                 modality=DataModality.MULTIVARIATE_REGRESSION,
@@ -190,7 +194,7 @@ class TestMeasurementConfig(ConfigComparisonsMixin, unittest.TestCase):
 
         config = MeasurementConfig(
             temporality=TemporalityType.DYNAMIC,
-            modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
+            modality=DataModality.MULTI_LABEL_CLASSIFICATION,
         )
 
         with self.assertRaises(ValueError):
@@ -280,7 +284,7 @@ class TestMeasurementConfig(ConfigComparisonsMixin, unittest.TestCase):
     def test_to_and_from_dict(self):
         default_dict = {
             "name": None,
-            "modality": DataModality.SINGLE_LABEL_CLASSIFICATION,
+            "modality": DataModality.MULTI_LABEL_CLASSIFICATION,
             "temporality": TemporalityType.DYNAMIC,
             "vocabulary": None,
             "observation_frequency": None,
@@ -302,7 +306,7 @@ class TestMeasurementConfig(ConfigComparisonsMixin, unittest.TestCase):
                 "msg": "Should work when all params are None.",
                 "config": MeasurementConfig(
                     temporality=TemporalityType.DYNAMIC,
-                    modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
+                    modality=DataModality.MULTI_LABEL_CLASSIFICATION,
                 ),
                 "want_dict": {**default_dict},
             },

--- a/tests/data/test_config.py
+++ b/tests/data/test_config.py
@@ -280,7 +280,6 @@ class TestMeasurementConfig(ConfigComparisonsMixin, unittest.TestCase):
     def test_to_and_from_dict(self):
         default_dict = {
             "name": None,
-            "present_in_event_types": None,
             "modality": DataModality.SINGLE_LABEL_CLASSIFICATION,
             "temporality": TemporalityType.DYNAMIC,
             "vocabulary": None,

--- a/tests/data/test_dataset_base.py
+++ b/tests/data/test_dataset_base.py
@@ -319,7 +319,7 @@ class TestDatasetBase(ConfigComparisonsMixin, unittest.TestCase):
     def test_get_source_df(self):
         dynamic = MeasurementConfig(
             temporality=TemporalityType.DYNAMIC,
-            modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
+            modality=DataModality.MULTI_LABEL_CLASSIFICATION,
         )
         static = MeasurementConfig(
             temporality=TemporalityType.STATIC, modality="single_label_classification"
@@ -442,7 +442,7 @@ class TestDatasetBase(ConfigComparisonsMixin, unittest.TestCase):
 
         base_measurement_config_kwargs = {
             "temporality": TemporalityType.DYNAMIC,
-            "modality": DataModality.SINGLE_LABEL_CLASSIFICATION,
+            "modality": DataModality.MULTI_LABEL_CLASSIFICATION,
         }
 
         retained_config = MeasurementConfig(**base_measurement_config_kwargs)

--- a/tests/data/test_dataset_base.py
+++ b/tests/data/test_dataset_base.py
@@ -113,10 +113,6 @@ class ESDMock(DatasetBase[dict, dict]):
     def build_DL_cached_representation(self):
         self.functions_called["build_DL_cached_representation"].append(())
 
-    def _get_valid_event_types(self) -> dict[str, list[str]]:
-        self.functions_called["_get_valid_event_types"].append(())
-        return {}
-
     def denormalize(self, events_df: dict, col: str) -> dict:
         self.functions_called["denormalize"].append((events_df, col))
         return events_df
@@ -323,7 +319,6 @@ class TestDatasetBase(ConfigComparisonsMixin, unittest.TestCase):
     def test_get_source_df(self):
         dynamic = MeasurementConfig(
             temporality=TemporalityType.DYNAMIC,
-            present_in_event_types=["a"],
             modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
         )
         static = MeasurementConfig(
@@ -340,7 +335,7 @@ class TestDatasetBase(ConfigComparisonsMixin, unittest.TestCase):
         cases = [
             {
                 "msg": (
-                    "Should filter to the appropriate event types and split and return the measurements df "
+                    "Should filter to the appropriate split and return the measurements df "
                     "when passed a dynamic measurement."
                 ),
                 "config": dynamic,
@@ -350,23 +345,7 @@ class TestDatasetBase(ConfigComparisonsMixin, unittest.TestCase):
                 "want_id": "measurement_id",
                 "want_fn": "_filter_col_inclusion",
                 "want_fn_arg": [
-                    (self.events_df, {"event_type": ["a"], "subject_id": [1, 2, 3]}),
-                    (self.dynamic_measurements_df, {"event_id": [1, 2]}),
-                ],
-            },
-            {
-                "msg": (
-                    "Should filter to the appropriate event types only and return the measurements df "
-                    "when passed a dynamic measurement and do_only_train = False"
-                ),
-                "config": dynamic,
-                "do_only_train": False,
-                "want_attr": "dynamic_measurements_df",
-                "want_df": self.dynamic_measurements_df,
-                "want_id": "measurement_id",
-                "want_fn": "_filter_col_inclusion",
-                "want_fn_arg": [
-                    (self.events_df, {"event_type": ["a"]}),
+                    (self.events_df, {"subject_id": [1, 2, 3]}),
                     (self.dynamic_measurements_df, {"event_id": [1, 2]}),
                 ],
             },
@@ -575,7 +554,6 @@ class TestDatasetBase(ConfigComparisonsMixin, unittest.TestCase):
                 ("retained", partial_retained_config_init, mock_source_df),
                 ("numeric", partial_numeric_config_init, mock_source_df),
             ],
-            "_get_valid_event_types": [()],
         }
         self.assertNestedDictEqual(want_functions_called, self.E.functions_called)
 

--- a/tests/data/test_dataset_polars.py
+++ b/tests/data/test_dataset_polars.py
@@ -612,7 +612,7 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.MULTI_LABEL_CLASSIFICATION,
         vocabulary=Vocabulary(["UNK", "foo", "bar"], [0, 2 / 3, 1 / 3]),
-        observation_frequency=1,
+        observation_frequency=9 / 21,
     ),
     "dynamic_dropped_insufficient_occurrences": MeasurementConfig(
         name="dynamic_dropped_insufficient_occurrences",

--- a/tests/data/test_dataset_polars.py
+++ b/tests/data/test_dataset_polars.py
@@ -104,7 +104,7 @@ MeasurementConfig.FUNCTORS["AgeFunctorMock"] = AgeFunctorMock
 MeasurementConfig.FUNCTORS["TimeOfDayFunctorMock"] = TimeOfDayFunctorMock
 
 TEST_CONFIG = DatasetConfig(
-    min_valid_column_observations=0.5,
+    min_valid_column_observations=1 / 9,
     min_valid_vocab_element_observations=2,
     min_true_float_frequency=1 / 2,
     min_unique_numerical_observations=0.99,
@@ -117,7 +117,7 @@ TEST_CONFIG = DatasetConfig(
         ),
         "not_present_dropped": MeasurementConfig(
             temporality=TemporalityType.DYNAMIC,
-            modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
+            modality=DataModality.MULTI_LABEL_CLASSIFICATION,
         ),
         "dynamic_preset_vocab": MeasurementConfig(
             temporality=TemporalityType.DYNAMIC,
@@ -126,7 +126,7 @@ TEST_CONFIG = DatasetConfig(
         ),
         "dynamic_dropped_insufficient_occurrences": MeasurementConfig(
             temporality=TemporalityType.DYNAMIC,
-            modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
+            modality=DataModality.MULTI_LABEL_CLASSIFICATION,
         ),
         "static": MeasurementConfig(
             temporality=TemporalityType.STATIC,
@@ -612,13 +612,13 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.MULTI_LABEL_CLASSIFICATION,
         vocabulary=Vocabulary(["UNK", "foo", "bar"], [0, 2 / 3, 1 / 3]),
-        observation_frequency=9 / 21,
+        observation_frequency=5 / 9,
     ),
     "dynamic_dropped_insufficient_occurrences": MeasurementConfig(
         name="dynamic_dropped_insufficient_occurrences",
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.DROPPED,
-        observation_frequency=0.5,
+        observation_frequency=1 / 9,
     ),
     "static": MeasurementConfig(
         name="static",
@@ -721,7 +721,7 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
                 ["mrbo1", "mrbo2", "mrbo3"], name="multivariate_regression_bounded_outliers"
             ),
         ),
-        observation_frequency=1,
+        observation_frequency=2 / 9,
         vocabulary=Vocabulary(["UNK", "mrbo1", "mrbo2", "mrbo3"], [0, 1, 1, 1]),
     ),
     "multivariate_regression_preset_value_type": MeasurementConfig(
@@ -761,7 +761,7 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
                 name="multivariate_regression_preset_value_type",
             ),
         ),
-        observation_frequency=1,
+        observation_frequency=2 / 9,
         vocabulary=Vocabulary(
             [
                 "UNK",
@@ -782,7 +782,7 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.MULTIVARIATE_REGRESSION,
         values_column="mrnp_vals",
-        observation_frequency=1,
+        observation_frequency=2 / 9,
         vocabulary=Vocabulary(
             [
                 "UNK",

--- a/tests/data/test_dataset_polars.py
+++ b/tests/data/test_dataset_polars.py
@@ -122,13 +122,11 @@ TEST_CONFIG = DatasetConfig(
         "dynamic_preset_vocab": MeasurementConfig(
             temporality=TemporalityType.DYNAMIC,
             modality=DataModality.MULTI_LABEL_CLASSIFICATION,
-            present_in_event_types=["DPV"],
             vocabulary=Vocabulary(["bar", "foo"], [1, 2]),
         ),
         "dynamic_dropped_insufficient_occurrences": MeasurementConfig(
             temporality=TemporalityType.DYNAMIC,
             modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
-            present_in_event_types=["DDIC"],
         ),
         "static": MeasurementConfig(
             temporality=TemporalityType.STATIC,
@@ -157,7 +155,6 @@ TEST_CONFIG = DatasetConfig(
             temporality=TemporalityType.DYNAMIC,
             modality=DataModality.MULTIVARIATE_REGRESSION,
             values_column="mrbo_vals",
-            present_in_event_types=["MVR"],
             _measurement_metadata=pd.DataFrame(
                 {
                     "drop_lower_bound": [-1.1, -10.1, None],
@@ -176,7 +173,6 @@ TEST_CONFIG = DatasetConfig(
             temporality=TemporalityType.DYNAMIC,
             modality=DataModality.MULTIVARIATE_REGRESSION,
             values_column="pvt_vals",
-            present_in_event_types=["MVR"],
             _measurement_metadata=pd.DataFrame(
                 {
                     "value_type": [
@@ -197,7 +193,6 @@ TEST_CONFIG = DatasetConfig(
             temporality=TemporalityType.DYNAMIC,
             modality=DataModality.MULTIVARIATE_REGRESSION,
             values_column="mrnp_vals",
-            present_in_event_types=["MVR"],
         ),
     },
 )
@@ -616,7 +611,6 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
         name="dynamic_preset_vocab",
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.MULTI_LABEL_CLASSIFICATION,
-        present_in_event_types=["DPV"],
         vocabulary=Vocabulary(["UNK", "foo", "bar"], [0, 2 / 3, 1 / 3]),
         observation_frequency=1,
     ),
@@ -624,7 +618,6 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
         name="dynamic_dropped_insufficient_occurrences",
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.DROPPED,
-        present_in_event_types=["DDIC"],
         observation_frequency=0.5,
     ),
     "static": MeasurementConfig(
@@ -700,7 +693,6 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.MULTIVARIATE_REGRESSION,
         values_column="mrbo_vals",
-        present_in_event_types=["MVR"],
         _measurement_metadata=pd.DataFrame(
             {
                 "drop_lower_bound": [-1.1, -10.1, None],
@@ -737,7 +729,6 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.MULTIVARIATE_REGRESSION,
         values_column="pvt_vals",
-        present_in_event_types=["MVR"],
         _measurement_metadata=pd.DataFrame(
             {
                 "value_type": [
@@ -791,7 +782,6 @@ WANT_INFERRED_MEASUREMENT_CONFIGS = {
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.MULTIVARIATE_REGRESSION,
         values_column="mrnp_vals",
-        present_in_event_types=["MVR"],
         observation_frequency=1,
         vocabulary=Vocabulary(
             [

--- a/tests/transformer/test_conditionally_independent_model.py
+++ b/tests/transformer/test_conditionally_independent_model.py
@@ -255,7 +255,6 @@ class TestConditionallyIndependentGenerativeOutputLayer(ConfigComparisonsMixin, 
                 regression_indices=regression_indices,
                 time_to_event=TTE_true,
             ),
-            "event_type_mask_per_measurement": "etmpm",
             "event_mask": "event_mask",
             "dynamic_values_mask": "dynamic_values_mask",
         }
@@ -279,7 +278,6 @@ class TestConditionallyIndependentGenerativeOutputLayer(ConfigComparisonsMixin, 
                 regression_indices=None,
                 time_to_event=None,
             ),
-            "event_type_mask_per_measurement": "etmpm",
             "event_mask": "event_mask",
             "dynamic_values_mask": "dynamic_values_mask",
         }
@@ -308,7 +306,6 @@ class TestConditionallyIndependentGenerativeOutputLayer(ConfigComparisonsMixin, 
                         dummy_batch,
                         shifted_encoded,
                         {"clf1", "mr1", "clf2", "clf3", "mr2"},
-                        event_type_mask_per_measurement="etmpm",
                     ),
                 ],
                 "regression_calls": [
@@ -317,7 +314,6 @@ class TestConditionallyIndependentGenerativeOutputLayer(ConfigComparisonsMixin, 
                         shifted_encoded,
                         {"mr1", "ur1", "mr2", "ur2"},
                         is_generation=False,
-                        event_type_mask_per_measurement="etmpm",
                     ),
                 ],
                 "TTE_calls": [call(dummy_batch, default_encoded, is_generation=False)],
@@ -331,7 +327,6 @@ class TestConditionallyIndependentGenerativeOutputLayer(ConfigComparisonsMixin, 
                         dummy_batch,
                         default_encoded,
                         {"clf1", "mr1", "clf2", "clf3", "mr2"},
-                        event_type_mask_per_measurement="etmpm",
                     ),
                 ],
                 "regression_calls": [
@@ -340,7 +335,6 @@ class TestConditionallyIndependentGenerativeOutputLayer(ConfigComparisonsMixin, 
                         default_encoded,
                         {"mr1", "ur1", "mr2", "ur2"},
                         is_generation=True,
-                        event_type_mask_per_measurement="etmpm",
                     ),
                 ],
                 "TTE_calls": [call(dummy_batch, default_encoded, is_generation=True)],
@@ -361,7 +355,6 @@ class TestConditionallyIndependentGenerativeOutputLayer(ConfigComparisonsMixin, 
                     DataModality.UNIVARIATE_REGRESSION: univariate_regression_measures,
                 }
 
-                M.get_event_type_mask_per_measurement = MagicMock(return_value="etmpm")
                 M.get_classification_outputs = MagicMock(return_value=default_classification_out)
                 M.get_regression_outputs = MagicMock(return_value=default_regression_out)
                 M.get_TTE_outputs = MagicMock(return_value=default_TTE_out)
@@ -380,8 +373,6 @@ class TestConditionallyIndependentGenerativeOutputLayer(ConfigComparisonsMixin, 
                     got = M(**kwargs)
                     want = GenerativeSequenceModelOutput(**case["want"])
                     self.assertEqual(want, got)
-
-                    M.get_event_type_mask_per_measurement.assert_called_once_with(dummy_batch)
 
                     classification_calls = case.get("classification_calls", [])
                     self.assertNestedCalledWith(M.get_classification_outputs, classification_calls)

--- a/tests/transformer/test_model_output.py
+++ b/tests/transformer/test_model_output.py
@@ -52,14 +52,6 @@ MEASUREMENT_CONFIGS = {
             obs_frequencies=[0.1, 0.3, 0.22, 0.2, 0.18],
         ),
     ),
-    "dynamic_single_label_clf": MeasurementConfig(
-        temporality=TemporalityType.DYNAMIC,
-        modality=DataModality.SINGLE_LABEL_CLASSIFICATION,
-        vocabulary=Vocabulary(
-            vocabulary=["UNK", "dynamic_single_label_1", "dynamic_single_label_2"],
-            obs_frequencies=[0.1, 0.5, 0.4],
-        ),
-    ),
     "dynamic_multi_label_clf": MeasurementConfig(
         temporality=TemporalityType.DYNAMIC,
         modality=DataModality.MULTI_LABEL_CLASSIFICATION,
@@ -111,7 +103,7 @@ MEASUREMENT_CONFIGS = {
 }
 
 MEASUREMENTS_PER_GEN_MODE = {
-    DataModality.SINGLE_LABEL_CLASSIFICATION: ["event_type", "dynamic_single_label_clf"],
+    DataModality.SINGLE_LABEL_CLASSIFICATION: ["event_type"],
     DataModality.MULTI_LABEL_CLASSIFICATION: [
         "dynamic_multi_label_clf",
         "dynamic_multivariate_reg",
@@ -125,7 +117,7 @@ MEASUREMENTS_IDXMAP = {
     "unused": 3,
     "age": 4,
     "tod": 5,
-    "dynamic_single_label_clf": 6,
+    "UNUSED": 6,
     "dynamic_multi_label_clf": 7,
     "dynamic_univariate_reg": 8,
     "dynamic_multivariate_reg": 9,
@@ -137,7 +129,6 @@ VOCAB_SIZES_BY_MEASUREMENT = {
     "unused": 1,
     "age": 1,
     "tod": 5,
-    "dynamic_single_label_clf": 3,
     "dynamic_multi_label_clf": 4,
     "dynamic_univariate_reg": 1,
     "dynamic_multivariate_reg": 3,
@@ -148,7 +139,6 @@ VOCAB_OFFSETS_BY_MEASUREMENT = {
     "unused": 6,
     "age": 7,
     "tod": 8,
-    "dynamic_single_label_clf": 13,
     "dynamic_multi_label_clf": 16,
     "dynamic_univariate_reg": 20,
     "dynamic_multivariate_reg": 21,
@@ -163,7 +153,6 @@ UNIFIED_VOCABULARY = {
     "static_clf": ["UNK", "static_clf_1", "static_clf_2"],
     "age": None,
     "tod": ["UNK", "EARLY_AM", "LATE_PM", "AM", "PM"],
-    "dynamic_single_label_clf": ["UNK", "dynamic_single_label_1", "dynamic_single_label_2"],
     "dynamic_multi_label_clf": [
         "UNK",
         "dynamic_multi_label_1",
@@ -182,11 +171,6 @@ UNIFIED_IDXMAP = {
     "static_clf": {"UNK": 3, "static_clf_1": 4, "static_clf_2": 5},
     "age": {None: 7},
     "tod": {"UNK": 8, "EARLY_AM": 9, "LATE_PM": 10, "AM": 11, "PM": 12},
-    "dynamic_single_label_clf": {
-        "UNK": 13,
-        "dynamic_single_label_1": 14,
-        "dynamic_single_label_2": 15,
-    },
     "dynamic_multi_label_clf": {
         "UNK": 16,
         "dynamic_multi_label_1": 17,
@@ -287,8 +271,8 @@ BASE_BATCH = {
                     MEASUREMENTS_IDXMAP["age"],
                     MEASUREMENTS_IDXMAP["tod"],
                     MEASUREMENTS_IDXMAP["dynamic_multivariate_reg"],
-                    MEASUREMENTS_IDXMAP["dynamic_single_label_clf"],
                     MEASUREMENTS_IDXMAP["dynamic_multivariate_reg"],
+                    0,
                 ],
             ],
             [
@@ -336,8 +320,8 @@ BASE_BATCH = {
                     UNIFIED_IDXMAP["age"][None],
                     UNIFIED_IDXMAP["tod"]["AM"],
                     UNIFIED_IDXMAP["dynamic_multivariate_reg"]["dynamic_multivariate_reg_1"],
-                    UNIFIED_IDXMAP["dynamic_single_label_clf"]["dynamic_single_label_1"],
                     UNIFIED_IDXMAP["dynamic_multivariate_reg"]["dynamic_multivariate_reg_2"],
+                    0,
                 ],
             ],
             [
@@ -445,8 +429,8 @@ WANT_APPENDED_BATCH = {
                     MEASUREMENTS_IDXMAP["age"],
                     MEASUREMENTS_IDXMAP["tod"],
                     MEASUREMENTS_IDXMAP["dynamic_multivariate_reg"],
-                    MEASUREMENTS_IDXMAP["dynamic_single_label_clf"],
                     MEASUREMENTS_IDXMAP["dynamic_multivariate_reg"],
+                    0,
                 ],
                 [MEASUREMENTS_IDXMAP["age"], MEASUREMENTS_IDXMAP["tod"], 0, 0, 0, 0],
             ],
@@ -496,8 +480,8 @@ WANT_APPENDED_BATCH = {
                     UNIFIED_IDXMAP["age"][None],
                     UNIFIED_IDXMAP["tod"]["AM"],
                     UNIFIED_IDXMAP["dynamic_multivariate_reg"]["dynamic_multivariate_reg_1"],
-                    UNIFIED_IDXMAP["dynamic_single_label_clf"]["dynamic_single_label_1"],
                     UNIFIED_IDXMAP["dynamic_multivariate_reg"]["dynamic_multivariate_reg_2"],
+                    0,
                 ],
                 [UNIFIED_IDXMAP["age"][None], UNIFIED_IDXMAP["tod"]["AM"], 0, 0, 0, 0],
             ],
@@ -571,7 +555,6 @@ WANT_APPENDED_BATCH = {
 #     "static_clf": ["UNK", "static_clf_1", "static_clf_2"],
 #     "age": None,
 #     "tod": ["UNK", "EARLY_AM", "LATE_PM", "AM", "PM"],
-#     "dynamic_single_label_clf": ["UNK", "dynamic_single_label_1", "dynamic_single_label_2"],
 #     "dynamic_multi_label_clf": [
 #         "UNK",
 #         "dynamic_multi_label_1",
@@ -587,7 +570,6 @@ WANT_APPENDED_BATCH = {
 # }
 CLASSIFICATION = {
     "event_type": torch.LongTensor([1, 1]),
-    "dynamic_single_label_clf": torch.LongTensor([2, 1]),
     "dynamic_multi_label_clf": torch.LongTensor(
         [
             [0, 0, 0, 0],
@@ -615,7 +597,6 @@ WANT_UPDATED_DATA = [
     (
         [
             "event_type",
-            "dynamic_single_label_clf",
             ("dynamic_multivariate_reg", "categorical_only"),
         ],
         {
@@ -625,15 +606,15 @@ WANT_UPDATED_DATA = [
                         MEASUREMENTS_IDXMAP["age"],
                         MEASUREMENTS_IDXMAP["tod"],
                         MEASUREMENTS_IDXMAP["event_type"],
-                        MEASUREMENTS_IDXMAP["dynamic_single_label_clf"],
                         MEASUREMENTS_IDXMAP["dynamic_multivariate_reg"],
+                        0,
                         0,
                     ],
                     [
                         MEASUREMENTS_IDXMAP["age"],
                         MEASUREMENTS_IDXMAP["tod"],
                         MEASUREMENTS_IDXMAP["event_type"],
-                        MEASUREMENTS_IDXMAP["dynamic_single_label_clf"],
+                        0,
                         0,
                         0,
                     ],
@@ -645,15 +626,15 @@ WANT_UPDATED_DATA = [
                         UNIFIED_IDXMAP["age"][None],
                         UNIFIED_IDXMAP["tod"]["AM"],
                         UNIFIED_IDXMAP["event_type"]["event_B"],
-                        UNIFIED_IDXMAP["dynamic_single_label_clf"]["dynamic_single_label_2"],
                         UNIFIED_IDXMAP["dynamic_multivariate_reg"]["dynamic_multivariate_reg_2"],
+                        0,
                         0,
                     ],
                     [
                         UNIFIED_IDXMAP["age"][None],
                         UNIFIED_IDXMAP["tod"]["EARLY_AM"],
                         UNIFIED_IDXMAP["event_type"]["event_B"],
-                        UNIFIED_IDXMAP["dynamic_single_label_clf"]["dynamic_single_label_1"],
+                        0,
                         0,
                         0,
                     ],
@@ -686,7 +667,6 @@ WANT_UPDATED_DATA = [
                         MEASUREMENTS_IDXMAP["age"],
                         MEASUREMENTS_IDXMAP["tod"],
                         MEASUREMENTS_IDXMAP["event_type"],
-                        MEASUREMENTS_IDXMAP["dynamic_single_label_clf"],
                         MEASUREMENTS_IDXMAP["dynamic_univariate_reg"],
                         MEASUREMENTS_IDXMAP["dynamic_multivariate_reg"],
                         0,
@@ -695,7 +675,6 @@ WANT_UPDATED_DATA = [
                         MEASUREMENTS_IDXMAP["age"],
                         MEASUREMENTS_IDXMAP["tod"],
                         MEASUREMENTS_IDXMAP["event_type"],
-                        MEASUREMENTS_IDXMAP["dynamic_single_label_clf"],
                         MEASUREMENTS_IDXMAP["dynamic_univariate_reg"],
                         MEASUREMENTS_IDXMAP["dynamic_multi_label_clf"],
                         MEASUREMENTS_IDXMAP["dynamic_multi_label_clf"],
@@ -708,7 +687,6 @@ WANT_UPDATED_DATA = [
                         UNIFIED_IDXMAP["age"][None],
                         UNIFIED_IDXMAP["tod"]["AM"],
                         UNIFIED_IDXMAP["event_type"]["event_B"],
-                        UNIFIED_IDXMAP["dynamic_single_label_clf"]["dynamic_single_label_2"],
                         UNIFIED_IDXMAP["dynamic_univariate_reg"][None],
                         UNIFIED_IDXMAP["dynamic_multivariate_reg"]["dynamic_multivariate_reg_2"],
                         0,
@@ -717,7 +695,6 @@ WANT_UPDATED_DATA = [
                         UNIFIED_IDXMAP["age"][None],
                         UNIFIED_IDXMAP["tod"]["EARLY_AM"],
                         UNIFIED_IDXMAP["event_type"]["event_B"],
-                        UNIFIED_IDXMAP["dynamic_single_label_clf"]["dynamic_single_label_1"],
                         UNIFIED_IDXMAP["dynamic_univariate_reg"][None],
                         UNIFIED_IDXMAP["dynamic_multi_label_clf"]["dynamic_multi_label_1"],
                         UNIFIED_IDXMAP["dynamic_multi_label_clf"]["dynamic_multi_label_3"],
@@ -730,14 +707,12 @@ WANT_UPDATED_DATA = [
                         NEW_EVENT_AGES[0],
                         0,
                         0,
-                        0,
                         0.8,
                         0.5,
                         0,
                     ],
                     [
                         NEW_EVENT_AGES[1],
-                        0,
                         0,
                         0,
                         0.2,
@@ -748,8 +723,8 @@ WANT_UPDATED_DATA = [
             ),
             "dynamic_values_mask": torch.BoolTensor(
                 [
-                    [True, False, False, False, True, True, False],
-                    [True, False, False, False, True, False, False],
+                    [True, False, False, True, True, False],
+                    [True, False, False, True, False, False],
                 ]
             ),
         },

--- a/tests/transformer/test_nested_attention_model.py
+++ b/tests/transformer/test_nested_attention_model.py
@@ -237,7 +237,6 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                 regression_indices=regression_indices,
                 time_to_event=TTE_true,
             ),
-            "event_type_mask_per_measurement": "etmpm",
             "event_mask": "event_mask",
             "dynamic_values_mask": "dynamic_values_mask",
         }
@@ -261,7 +260,6 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                 regression_indices=None,
                 time_to_event=None,
             ),
-            "event_type_mask_per_measurement": "etmpm",
             "event_mask": "event_mask",
             "dynamic_values_mask": "dynamic_values_mask",
         }
@@ -285,7 +283,6 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                 regression_indices=None,
                 time_to_event=None,
             ),
-            "event_type_mask_per_measurement": "etmpm",
             "event_mask": "event_mask",
             "dynamic_values_mask": "dynamic_values_mask",
         }
@@ -333,19 +330,16 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                         dummy_batch,
                         default_encoded[:, :, 0, :],
                         {"clf1", "mr1"},
-                        event_type_mask_per_measurement="etmpm",
                     ),
                     call(
                         dummy_batch,
                         default_encoded[:, :, 1, :],
                         {"clf2"},
-                        event_type_mask_per_measurement="etmpm",
                     ),
                     call(
                         dummy_batch,
                         default_encoded[:, :, 2, :],
                         {"clf3", "mr2"},
-                        event_type_mask_per_measurement="etmpm",
                     ),
                 ],
                 "regression_calls": [
@@ -354,21 +348,18 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                         default_encoded[:, :, 0, :],
                         set(),
                         is_generation=False,
-                        event_type_mask_per_measurement="etmpm",
                     ),
                     call(
                         dummy_batch,
                         default_encoded[:, :, 1, :],
                         {"mr1", "ur1"},
                         is_generation=False,
-                        event_type_mask_per_measurement="etmpm",
                     ),
                     call(
                         dummy_batch,
                         default_encoded[:, :, 2, :],
                         {"mr2", "ur2"},
                         is_generation=False,
-                        event_type_mask_per_measurement="etmpm",
                     ),
                 ],
                 "TTE_calls": [
@@ -396,7 +387,6 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                         dummy_batch,
                         default_encoded[:, :, 0, :],
                         {"clf2"},
-                        event_type_mask_per_measurement="etmpm",
                     ),
                 ],
                 "regression_calls": [
@@ -405,7 +395,6 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                         default_encoded[:, :, 0, :],
                         {"mr1", "ur1"},
                         is_generation=True,
-                        event_type_mask_per_measurement="etmpm",
                     ),
                 ],
                 "TTE_calls": [],
@@ -446,7 +435,6 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                     DataModality.UNIVARIATE_REGRESSION: univariate_regression_measures,
                 }
 
-                M.get_event_type_mask_per_measurement = MagicMock(return_value="etmpm")
                 M.get_classification_outputs = MagicMock(return_value=default_classification_out)
                 M.get_regression_outputs = MagicMock(return_value=default_regression_out)
                 M.get_TTE_outputs = MagicMock(return_value=default_TTE_out)
@@ -466,8 +454,6 @@ class TestNestedAttentionGenerativeOutputLayer(ConfigComparisonsMixin, unittest.
                     got = M(**kwargs)
                     want = GenerativeSequenceModelOutput(**case["want"])
                     self.assertEqual(want, got)
-
-                    M.get_event_type_mask_per_measurement.assert_called_once_with(dummy_batch)
 
                     classification_calls = case.get("classification_calls", [])
                     self.assertNestedCalledWith(M.get_classification_outputs, classification_calls)


### PR DESCRIPTION
Does two things:
(1) Removes the ability for measurements to explicitly be configured to occur only on select event types.
(2) Removes support for dynamic single-label classification tasks (aside from `event_type`, which is a special case and always mandated to be single label).

These are necessary for the following reasons:
(1) For event type specificity to be meaningful during generation, we need to have post processing that removes measurements not allowed _after_ event types have been generated, which we currently don't have. As a result, this current functionality is broken. It _should_ be re-added (correctly) at some point, with tests to validate it, but until then it should be removed so as to avoid broken portions of the code.
(2) Without the ability to state that a measurement is specific to an event type, dynamic, single-label classification tasks don't actually make that much sense, as there is an inherent assumption in them that they will always be measured exactly one time (on their allowed event types). As we support event aggregation, many "single label" tasks in reality end up being multi-label (as multiple valid events get aggregated together) and without event type support others end up being only partially observed single label tasks, which we don't currently support (as we'd need to predict (a) whether the task is measured at all and if so then (b) what label is observed, whereas now we just predict (b) by virtue of the assumption it is universally observed on valid event types.)